### PR TITLE
feat: allow server-side hydration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ package-lock.json
 
 # Output
 dist/
+hydrate/
 docs/
 build-scripts/
 build/

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # `Discord Components`
+
 A fork of [@skyra-project/discord-components](https://github.com/skyra-project/discord-components) designed for use in [discord-html-transcripts](https://github.com/itzderock/discord-html-transcripts)
 
 ## Changes
-- Adds `<discord-code-block>`
-- Adds `<discord-header>`
-- Adds better support in `<discord-time>`
-	- Automatically updating based on timestamp and format option
-- Adds better support in `<discord-attachment>`
-	- Adds support for generic attachments, videos, and audio
-(changes also reflected in the react bindings)
+
+-   Adds `<discord-code-block>`
+-   Adds `<discord-header>`
+-   Adds better support in `<discord-time>`
+    -   Automatically updating based on timestamp and format option
+-   Adds better support in `<discord-attachment>`
+    -   Adds support for generic attachments, videos, and audio
+-   Adds option to do server-side hydration
+    (changes also reflected in the react bindings)
 
 ## Original README:
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,13 +1,16 @@
 # `@derockdev/discord-components-core`
+
 A fork of [@skyra/discord-components-core](https://github.com/skyra-project/discord-components) designed for use in [discord-html-transcripts](https://github.com/itzderock/discord-html-transcripts)
 
 ## Changes
-- Adds `<discord-code-block>`
-- Adds `<discord-header>`
-- Adds better support in `<discord-time>`
-	- Automatically updating based on timestamp and format option
-- Adds better support in `<discord-attachment>`
-	- Adds support for generic attachments, videos, and audio
+
+-   Adds `<discord-code-block>`
+-   Adds `<discord-header>`
+-   Adds better support in `<discord-time>`
+    -   Automatically updating based on timestamp and format option
+-   Adds better support in `<discord-attachment>`
+    -   Adds support for generic attachments, videos, and audio
+-   Adds option to do server-side hydration
 
 ## Original README:
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,13 @@
 				"import": "./loader/index.js"
 			},
 			"./loader/index.cjs.js"
+		],
+		"./hydrate": [
+			{
+				"require": "./hydrate/index.js",
+				"import": "./hydrate/index.js"
+			},
+			"./hydrate/index.js"
 		]
 	},
 	"sideEffects": [

--- a/packages/core/stencil.config.ts
+++ b/packages/core/stencil.config.ts
@@ -26,6 +26,7 @@ export const config: Config = {
 			type: 'www',
 			serviceWorker: null,
 			copy: [{ src: '../static', dest: 'static/' }]
-		}
+		},
+		{ type: 'dist-hydrate-script' }
 	]
 };


### PR DESCRIPTION
### Reason

This change should allow hydrating the generated HTML server-side, so that we can send fully hydrated HTML to the client

### Example

```ts
import { renderToString } from '@derockdev/discord-components-core/hydrate';

const html = await generateHtmlFromMessages(messages);
const result = await renderToString(html);
console.log(result.html); // is fully hydrated
```