### PR TITLE
fix: 12-hour clock displaying 00 for the hour

### DIFF
--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -7,7 +7,7 @@ export const handleTimestamp = (value: DiscordTimestamp, hour24 = false): string
 		throw new TypeError('Timestamp prop must be a Date object or a string.');
 	}
 
-	return new Date(value)
+	const date = new Date(value)
 		.toLocaleDateString(undefined, {
 			year: 'numeric',
 			month: '2-digit',
@@ -17,6 +17,8 @@ export const handleTimestamp = (value: DiscordTimestamp, hour24 = false): string
 			hour12: !hour24
 		})
 		.replace(',', '');
+
+	return hour24 ? date : date.replace(/00:(\d{2})/, '12:$1');
 };
 
 export const getGlobalEmojiUrl = (emojiName: string): Emoji | undefined => window.$discordMessage?.emojis?.[emojiName];

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,7 +255,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@derockdev/discord-components-core@^3.5.1, @derockdev/discord-components-core@workspace:packages/core":
+"@derockdev/discord-components-core@^3.6.1, @derockdev/discord-components-core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@derockdev/discord-components-core@workspace:packages/core"
   dependencies:
@@ -273,7 +273,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@derockdev/discord-components-react@workspace:packages/react"
   dependencies:
-    "@derockdev/discord-components-core": ^3.5.1
+    "@derockdev/discord-components-core": ^3.6.1
     gen-esm-wrapper: ^1.1.3
     replace-in-file: ^6.3.5
     tslib: ^2.6.0


### PR DESCRIPTION
Fixes ItzDerock/discord-html-transcripts#142

This fixes the issue of [Date#toLocaleDateString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString) displaying 00 for the hour, when the 12 hour clock is being used. 

Example of the regex being used:
```js
"10/08/2023 00:21 pm".replace(/00:(\d{2})/, "12:$1")
// outputs: '10/08/2023 12:21 pm'

"10/08/2023 00:21 am".replace(/00:(\d{2})/, "12:$1")
// outputs: '10/08/2023 12:21 am'
```

It also updates yarn.lock so that `yarn --immutable` can complete successfully.